### PR TITLE
Fix django-formtools version change

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ bcrypt~=3.1.7
 psycopg2~=2.8.4
 
 #django helpers
-django-formtools~=2.2
+django-formtools==2.2
 python-dateutil~=2.8.1 
 
 #calendar requirements


### PR DESCRIPTION
Version `2.4` of django-formtools breaks backwards compatibility so pinning version